### PR TITLE
GCP Functions를 이용한 GCP Run에 병렬 요청 처리 구성 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /build_aws_lambda_docker_image.sh
 /build_azure_function_docker_image.sh
 /build_gcp_run_docker_image.sh
+/build_gcp_run_python_docker_image.sh
 /create_gcp_functions_code_zip.sh
 
 ### Model files

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 ### build sh
 /bench/bench_in_faas/aws_lambda/build_assets/build.sh
+/bench/bench_in_faas/gcp_run/build_assets/build.sh
 /build_aws_lambda_docker_image.sh
 /build_azure_function_docker_image.sh
 /build_gcp_run_docker_image.sh
@@ -23,6 +24,7 @@
 /yolo_v5.zip
 /bert_imdb.zip
 /distilbert_sst2.zip
+/bench/bench_in_faas/gcp_run/build_assets/scpc_bench.zip
 
 ### Dataset files
 /dataset/imagenet
@@ -35,6 +37,7 @@ tmp_file
 
 ### Variables
 /bench/bench_in_faas/aws_lambda/variables.py
+/bench/bench_in_faas/gcp_run/variables.py
 /bench/bench_in_instance/aws_lambda_variables.py
 /bench/bench_in_instance/azure_function_variables.py
 /bench/bench_in_instance/gcp_run_variables.py
@@ -44,6 +47,7 @@ tmp_file
 /bench/bench_in_instance/bench_azure_infra/variables.tf
 /bench/bench_in_instance/bench_gcp_infra/variables.tf
 /bench/bench_in_faas/aws_lambda/IaC/variables.tf
+/bench/bench_in_faas/gcp_run/IaC/variables.tf
 /IaC/AWS-Lambda-IaC/variables.tf
 /IaC/Azure-Function-IaC/variables.tf
 /IaC/GCP-Run-IaC/variables.tf

--- a/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
@@ -4,6 +4,7 @@ resource "google_cloud_run_service" "cloudrun_service" {
   location = var.region
   template {
     spec {
+      container_concurrency = var.concurrency
       containers {
         image = "${var.docker_registry}/gcp-run-${var.model_name}-${var.APIS[count.index]}"
         ports {

--- a/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
@@ -1,10 +1,5 @@
-variable "APIS" {
-  type    = list(string)
-  default = ["grpc", "rest"]
-}
-
 resource "google_cloud_run_service" "cloudrun_service" {
-  count    = 2
+  count    = length(var.APIS)
   name     = "${replace(var.model_name,"_","-")}-${var.APIS[count.index]}"
   location = var.region
   template {
@@ -48,7 +43,7 @@ resource "google_cloud_run_service" "cloudrun_service" {
 }
 
 resource "google_cloud_run_service_iam_policy" "cloudrun_noauth" {
-  count    = 2
+  count    = length(var.APIS)
   location = google_cloud_run_service.cloudrun_service[count.index].location
   project  = google_cloud_run_service.cloudrun_service[count.index].project
   service  = google_cloud_run_service.cloudrun_service[count.index].name

--- a/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
@@ -1,6 +1,6 @@
 resource "google_cloud_run_service" "cloudrun_service" {
   count    = length(var.APIS)
-  name     = "${replace(var.model_name,"_","-")}-${var.APIS[count.index]}"
+  name     = "${replace(var.model_name, "_", "-")}-${var.APIS[count.index]}"
   location = var.region
   template {
     spec {
@@ -32,7 +32,7 @@ resource "google_cloud_run_service" "cloudrun_service" {
     }
     metadata {
       annotations = {
-        "autoscaling.knative.dev/minScale"  = var.min_instances
+        "autoscaling.knative.dev/minScale" = var.min_instances
         "autoscaling.knative.dev/maxScale" = var.max_instances
       }
     }
@@ -51,3 +51,297 @@ resource "google_cloud_run_service_iam_policy" "cloudrun_noauth" {
 
   policy_data = var.noauth_policy
 }
+
+# resource "google_bigquery_dataset" "dataset" {
+#   dataset_id                  = "${var.prefix}_${var.model_name}"
+#   friendly_name               = "${var.prefix}_${var.model_name}"
+#   location                    = var.region
+#   default_table_expiration_ms = 3600000
+# }
+
+# resource "google_bigquery_table" "dataset-table" {
+#   count               = length(var.APIS)
+#   dataset_id          = "${var.prefix}_${var.model_name}"
+#   table_id            = var.APIS[count.index]
+#   deletion_protection = false
+#   depends_on          = [google_bigquery_dataset.dataset]
+#   expiration_time     = 0
+
+#   schema              = <<EOF
+# [
+#   {
+#     "mode": "NULLABLE",
+#     "name": "logName",
+#     "type": "STRING"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "type",
+#         "type": "STRING"
+#       },
+#       {
+#         "fields": [
+#           {
+#             "mode": "NULLABLE",
+#             "name": "revision_name",
+#             "type": "STRING"
+#           },
+#           {
+#             "mode": "NULLABLE",
+#             "name": "configuration_name",
+#             "type": "STRING"
+#           },
+#           {
+#             "mode": "NULLABLE",
+#             "name": "service_name",
+#             "type": "STRING"
+#           },
+#           {
+#             "mode": "NULLABLE",
+#             "name": "location",
+#             "type": "STRING"
+#           },
+#           {
+#             "mode": "NULLABLE",
+#             "name": "project_id",
+#             "type": "STRING"
+#           }
+#         ],
+#         "mode": "NULLABLE",
+#         "name": "labels",
+#         "type": "RECORD"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "resource",
+#     "type": "RECORD"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "textPayload",
+#     "type": "STRING"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "timestamp",
+#     "type": "TIMESTAMP"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "receiveTimestamp",
+#     "type": "TIMESTAMP"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "severity",
+#     "type": "STRING"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "insertId",
+#     "type": "STRING"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "requestMethod",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "requestUrl",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "requestSize",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "status",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "responseSize",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "userAgent",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "remoteIp",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "serverIp",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "referer",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "latency",
+#         "type": "FLOAT"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "cacheLookup",
+#         "type": "BOOLEAN"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "cacheHit",
+#         "type": "BOOLEAN"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "cacheValidatedWithOriginServer",
+#         "type": "BOOLEAN"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "cacheFillBytes",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "protocol",
+#         "type": "STRING"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "httpRequest",
+#     "type": "RECORD"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "instanceid",
+#         "type": "STRING"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "labels",
+#     "type": "RECORD"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "id",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "producer",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "first",
+#         "type": "BOOLEAN"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "last",
+#         "type": "BOOLEAN"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "operation",
+#     "type": "RECORD"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "trace",
+#     "type": "STRING"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "spanId",
+#     "type": "STRING"
+#   },
+#   {
+#     "mode": "NULLABLE",
+#     "name": "traceSampled",
+#     "type": "BOOLEAN"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "file",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "line",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "function",
+#         "type": "STRING"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "sourceLocation",
+#     "type": "RECORD"
+#   },
+#   {
+#     "fields": [
+#       {
+#         "mode": "NULLABLE",
+#         "name": "uid",
+#         "type": "STRING"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "index",
+#         "type": "INTEGER"
+#       },
+#       {
+#         "mode": "NULLABLE",
+#         "name": "totalSplits",
+#         "type": "INTEGER"
+#       }
+#     ],
+#     "mode": "NULLABLE",
+#     "name": "split",
+#     "type": "RECORD"
+#   }
+# ]
+# EOF
+# }
+
+# resource "google_logging_project_sink" "logging_sink" {
+#   count       = length(var.APIS)
+#   name        = "${var.prefix}-${var.model_name}-${var.APIS[count.index]}-sink"
+#   destination = "bigquery.googleapis.com/projects/${var.project_name}/datasets/${var.prefix}_${var.model_name}/tables/${var.APIS[count.index]}"
+
+#   filter                 = var.APIS[count.index] == "grpc" ? "httpRequest.status=200 httpRequest.requestUrl=\"${google_cloud_run_service.cloudrun_service[count.index].status[0].url}/tensorflow.serving.PredictionService/Predict\"" : "httpRequest.status=200 httpRequest.requestUrl=\"${google_cloud_run_service.cloudrun_service[count.index].status[0].url}/v1/models/${var.model_name}:predict\""
+#   depends_on             = [google_bigquery_table.dataset-table]
+#   unique_writer_identity = true
+# }
+
+# resource "google_logging_project_sink" "logging_sink" {
+#   count       = length(var.APIS)
+#   name        = "${var.prefix}-${var.model_name}-${var.APIS[count.index]}-sink"
+#   destination = "bigquery.googleapis.com/projects/${var.project_name}/datasets/${var.prefix}_${var.model_name}"
+
+#   filter                 = var.APIS[count.index] == "grpc" ? "httpRequest.status=200 httpRequest.requestUrl=\"${google_cloud_run_service.cloudrun_service[count.index].status[0].url}/tensorflow.serving.PredictionService/Predict\"" : "httpRequest.status=200 httpRequest.requestUrl=\"${google_cloud_run_service.cloudrun_service[count.index].status[0].url}/v1/models/${var.model_name}:predict\""
+#   unique_writer_identity = true
+# }

--- a/IaC/GCP-Run-IaC/cloudrun/variables.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/variables.tf
@@ -7,3 +7,4 @@ variable "min_instances" {}
 variable "max_instances" {}
 variable "noauth_policy" {}
 variable "APIS" {}
+variable "concurrency" {}

--- a/IaC/GCP-Run-IaC/cloudrun/variables.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/variables.tf
@@ -7,4 +7,6 @@ variable "min_instances" {}
 variable "max_instances" {}
 variable "noauth_policy" {}
 variable "APIS" {}
+variable "prefix" {}
 variable "concurrency" {}
+variable "project_name" {}

--- a/IaC/GCP-Run-IaC/cloudrun/variables.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/variables.tf
@@ -6,3 +6,4 @@ variable "ram_mib" {}
 variable "min_instances" {}
 variable "max_instances" {}
 variable "noauth_policy" {}
+variable "APIS" {}

--- a/IaC/GCP-Run-IaC/cloudruns.tf
+++ b/IaC/GCP-Run-IaC/cloudruns.tf
@@ -13,4 +13,6 @@ module "cloudrun" {
   noauth_policy   = data.google_iam_policy.noauth.policy_data
   APIS            = var.APIS
   concurrency     = var.concurrency
+  project_name    = var.project
+  prefix          = var.prefix
 }

--- a/IaC/GCP-Run-IaC/cloudruns.tf
+++ b/IaC/GCP-Run-IaC/cloudruns.tf
@@ -11,4 +11,5 @@ module "cloudrun" {
   min_instances   = var.model_resources[var.enabled_models[count.index]].min_instances
   max_instances   = var.model_resources[var.enabled_models[count.index]].max_instances
   noauth_policy   = data.google_iam_policy.noauth.policy_data
+  APIS            = var.APIS
 }

--- a/IaC/GCP-Run-IaC/cloudruns.tf
+++ b/IaC/GCP-Run-IaC/cloudruns.tf
@@ -12,4 +12,5 @@ module "cloudrun" {
   max_instances   = var.model_resources[var.enabled_models[count.index]].max_instances
   noauth_policy   = data.google_iam_policy.noauth.policy_data
   APIS            = var.APIS
+  concurrency     = var.concurrency
 }

--- a/IaC/GCP-Run-IaC/variables.tf.sample
+++ b/IaC/GCP-Run-IaC/variables.tf.sample
@@ -18,6 +18,11 @@ variable "docker_registry" {
   default = "change here!"
 }
 
+variable "APIS" {
+  type    = list(string)
+  default = ["grpc", "rest"]
+}
+
 variable "enabled_models" {
   type = list(string)
   default = [ "mobilenet_v1", "mobilenet_v2", "inception_v3", "yolo_v5", "bert_imdb"]

--- a/IaC/GCP-Run-IaC/variables.tf.sample
+++ b/IaC/GCP-Run-IaC/variables.tf.sample
@@ -23,11 +23,15 @@ variable "APIS" {
   default = ["grpc", "rest"]
 }
 
+variable "concurrency" {
+  type    = number
+  default = 1
+}
+
 variable "enabled_models" {
   type = list(string)
   default = [ "mobilenet_v1", "mobilenet_v2", "inception_v3", "yolo_v5", "bert_imdb"]
 }
-
 
 variable "model_resources" {
   type = object({

--- a/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
+++ b/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
@@ -18,6 +18,7 @@ resource "google_cloudfunctions_function" "cloudfunctions_function" {
   }
   timeouts {
     create = "15m"
+    update = "15m"
   }
 }
 

--- a/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
+++ b/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
@@ -14,6 +14,7 @@ resource "google_cloudfunctions_function" "cloudfunctions_function" {
   environment_variables = {
     AWS_ACCESS_KEY_ID     = var.aws_access_key
     AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key
+    AWS_REGION            = var.aws_region
   }
   timeouts {
     create = "15m"

--- a/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
+++ b/bench/bench_in_faas/gcp_run/IaC/cloudfunction.tf
@@ -1,0 +1,29 @@
+resource "google_cloudfunctions_function" "cloudfunctions_function" {
+  name                         = "${var.prefix}-scpc-bench"
+  region                       = var.region
+  runtime                      = "python310"
+  source_archive_bucket        = var.bucket_name
+  source_archive_object        = "scpc_bench.zip"
+  entry_point                  = "function_handler"
+  available_memory_mb          = 4096
+  min_instances                = 0
+  max_instances                = 300
+  timeout                      = 120
+  trigger_http                 = true
+  https_trigger_security_level = "SECURE_ALWAYS"
+  environment_variables = {
+    AWS_ACCESS_KEY_ID     = var.aws_access_key
+    AWS_SECRET_ACCESS_KEY = var.aws_secret_access_key
+  }
+  timeouts {
+    create = "15m"
+  }
+}
+
+resource "google_cloudfunctions_function_iam_member" "cloudfunction_noauth" {
+  region         = google_cloudfunctions_function.cloudfunctions_function.region
+  project        = google_cloudfunctions_function.cloudfunctions_function.project
+  cloud_function = google_cloudfunctions_function.cloudfunctions_function.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "allUsers"
+}

--- a/bench/bench_in_faas/gcp_run/IaC/main.tf
+++ b/bench/bench_in_faas/gcp_run/IaC/main.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project
+  region  = var.region
+}

--- a/bench/bench_in_faas/gcp_run/IaC/outputs.tf
+++ b/bench/bench_in_faas/gcp_run/IaC/outputs.tf
@@ -1,0 +1,3 @@
+output "cloudfunction_url" {
+  value = google_cloudfunctions_function.cloudfunctions_function.https_trigger_url
+}

--- a/bench/bench_in_faas/gcp_run/IaC/variables.tf.sample
+++ b/bench/bench_in_faas/gcp_run/IaC/variables.tf.sample
@@ -1,0 +1,31 @@
+variable "project" {
+  type = string
+  default = "change here!"
+}
+
+variable "region" {
+  type = string
+  default = "change here!"
+}
+
+variable "prefix" {
+  type = string
+  default = "change here!"
+}
+
+variable "bucket_name" {
+  type = string
+  default = "change here!"
+}
+
+variable "aws_access_key" {
+  type = string
+  sensitive = true
+  default = "change here!"
+}
+
+variable "aws_secret_access_key" {
+  type = string
+  sensitive = true
+  default = "change here!"
+}

--- a/bench/bench_in_faas/gcp_run/IaC/variables.tf.sample
+++ b/bench/bench_in_faas/gcp_run/IaC/variables.tf.sample
@@ -29,3 +29,8 @@ variable "aws_secret_access_key" {
   sensitive = true
   default = "change here!"
 }
+
+variable "aws_region" {
+  type = string
+  default = "change here!'
+}

--- a/bench/bench_in_faas/gcp_run/README.md
+++ b/bench/bench_in_faas/gcp_run/README.md
@@ -1,0 +1,1 @@
+This is GCP Functions code to bench GCP Run.

--- a/bench/bench_in_faas/gcp_run/build_assets/build.sh.sample
+++ b/bench/bench_in_faas/gcp_run/build_assets/build.sh.sample
@@ -1,0 +1,4 @@
+#!/bin/bash
+bucket_name=""
+zip -j scpc_bench.zip ./requirements.txt ./main.py
+gsutil cp scpc_bench.zip gs://$bucket_name

--- a/bench/bench_in_faas/gcp_run/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/build_assets/main.py
@@ -1,0 +1,62 @@
+import functions_framework
+import json
+import boto3
+import time
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+
+import tensorflow as tf
+from google.protobuf.json_format import Parse
+import grpc
+
+access_key = os.environ['AWS_ACCESS_KEY_ID']
+secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
+
+def create_grpc_stub(server_address, use_https):
+    # gRPC 채널 생성
+    if (use_https == "1"):
+        channel = grpc.secure_channel(server_address,grpc.ssl_channel_credentials(),options=[('grpc.max_send_message_length', 50 * 1024 * 1024), ('grpc.max_receive_message_length', 50 * 1024 * 1024)])
+    else:
+        channel = grpc.insecure_channel(server_address,options=[('grpc.max_send_message_length', 50 * 1024 * 1024), ('grpc.max_receive_message_length', 50 * 1024 * 1024)])
+
+    # gRPC 스텁 생성
+    stub = prediction_service_pb2_grpc.PredictionServiceStub(channel)
+    return stub
+
+def predict(stub, data):
+    request_time = time.time()
+    response = stub.Predict(data, timeout=100.0)
+    response_time = time.time()
+    network_latency_time = response_time - request_time
+    return response, network_latency_time
+
+def create_log_event(log_group_name, log_stream_name, inference_time, network_latency_time):
+    logs_client = boto3.client('logs', aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    log_data = {
+        'inference_time': inference_time,
+        'network_latency_time': network_latency_time
+    }
+    log_event = {
+        'timestamp':int (time.time() * 1000),
+        'message': json.dumps(log_data)
+    }
+    logs_client.put_log_events(logGroupName=log_group_name, logStreamName=log_stream_name, logEvents=[log_event])
+
+@functions_framework.http
+def function_handler(request):
+    if request.method == 'POST':
+        json_body = request.get_json(silent=True)
+        log_group_name = json_body['inputs']['log_group_name']
+        log_stream_name = json_body['inputs']['log_stream_name']
+        server_address = json_body['inputs']['server_address']
+        use_https = json_body['inputs']['use_https']
+        request_data = Parse(json_body['inputs']['request_data'])
+        stub = create_grpc_stub(server_address, use_https)
+        response, network_latency_time = predict(stub, request_data)
+        create_log_event(log_group_name, log_stream_name, "null", network_latency_time)
+        return json.dumps({'body': "Success"}), 200, {'Content-Type': 'application/json'}
+    else:
+        return json.dumps({
+            'body': "Please send POST request"
+        }), 403, {'Content-Type': 'application/json'}

--- a/bench/bench_in_faas/gcp_run/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/build_assets/main.py
@@ -5,8 +5,6 @@ import time
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 from tensorflow_serving.apis import prediction_service_pb2_grpc
-
-import tensorflow as tf
 from google.protobuf.json_format import Parse
 import grpc
 

--- a/bench/bench_in_faas/gcp_run/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/build_assets/main.py
@@ -53,7 +53,7 @@ def function_handler(request):
         use_https = json_body['inputs']['use_https']
         request_data = json_body['inputs']['request_data']
         protobuf_message = predict_pb2.PredictRequest()
-        ParseDict(request_data, protobuf_message)
+        ParseDict(json.loads(request_data), protobuf_message)
         stub = create_grpc_stub(server_address, use_https)
         response, network_latency_time = predict(stub, protobuf_message)
         create_log_event(log_group_name, log_stream_name, "null", network_latency_time)

--- a/bench/bench_in_faas/gcp_run/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/build_assets/main.py
@@ -10,8 +10,9 @@ import tensorflow as tf
 from google.protobuf.json_format import Parse
 import grpc
 
-access_key = os.environ['AWS_ACCESS_KEY_ID']
-secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
+aws_access_key = os.environ['AWS_ACCESS_KEY_ID']
+aws_secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
+aws_region = os.environ['AWS_REGION']
 
 def create_grpc_stub(server_address, use_https):
     # gRPC 채널 생성
@@ -32,7 +33,7 @@ def predict(stub, data):
     return response, network_latency_time
 
 def create_log_event(log_group_name, log_stream_name, inference_time, network_latency_time):
-    logs_client = boto3.client('logs', aws_access_key_id=access_key, aws_secret_access_key=secret_key)
+    logs_client = boto3.client('logs', aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, region_name=aws_region)
     log_data = {
         'inference_time': inference_time,
         'network_latency_time': network_latency_time

--- a/bench/bench_in_faas/gcp_run/build_assets/requirements.txt
+++ b/bench/bench_in_faas/gcp_run/build_assets/requirements.txt
@@ -1,0 +1,5 @@
+requests
+boto3
+tensorflow-serving-api==2.11.1
+tensorflow==2.11.1
+protobuf==3.19.6

--- a/bench/bench_in_faas/gcp_run/preprocess/bert_imdb.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/bert_imdb.py
@@ -5,6 +5,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 from keras.preprocessing.text import Tokenizer
 from keras.utils import pad_sequences
+from google.protobuf.json_format import MessageToJson
 
 def run_preprocessing(text):
     tokenizer = Tokenizer()
@@ -24,4 +25,5 @@ def create_request_data():
     data.inputs['input_ids'].CopyFrom(make_tensor_proto(input_ids, shape=[1, len(input_ids[0])]))
     data.inputs['input_masks'].CopyFrom(make_tensor_proto(input_masks, shape=[1, len(input_masks[0])]))
     data.inputs['segment_ids'].CopyFrom(make_tensor_proto(segment_ids, shape=[1, len(segment_ids[0])]))
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/preprocess/bert_imdb.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/bert_imdb.py
@@ -1,0 +1,27 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+from keras.preprocessing.text import Tokenizer
+from keras.utils import pad_sequences
+
+def run_preprocessing(text):
+    tokenizer = Tokenizer()
+    tokenizer.fit_on_texts([text])
+    input_ids = tokenizer.texts_to_sequences([text])
+    input_ids = pad_sequences(input_ids, maxlen=500, padding='post', truncating='post')
+    input_masks = [[1] * len(input_ids[0])]
+    segment_ids = [[0] * len(input_ids[0])]
+    return input_ids, input_masks, segment_ids 
+
+def create_request_data():
+    text = "This is a sample sentence to test the BERT model."
+    input_ids, input_masks, segment_ids = run_preprocessing(text)
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'bert_imdb'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['input_ids'].CopyFrom(make_tensor_proto(input_ids, shape=[1, len(input_ids[0])]))
+    data.inputs['input_masks'].CopyFrom(make_tensor_proto(input_masks, shape=[1, len(input_masks[0])]))
+    data.inputs['segment_ids'].CopyFrom(make_tensor_proto(segment_ids, shape=[1, len(segment_ids[0])]))
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/distilbert_sst2.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/distilbert_sst2.py
@@ -1,0 +1,26 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+from keras.preprocessing.text import Tokenizer
+from keras.utils import pad_sequences
+
+def run_preprocessing(text):
+    tokenizer = Tokenizer()
+    tokenizer.fit_on_texts([text])
+    bert_input_ids = tokenizer.texts_to_sequences([text])
+    bert_input_ids = pad_sequences(bert_input_ids, maxlen=128, padding='post', truncating='post')
+    bert_input_masks = [[1] * len(bert_input_ids[0])]
+
+    return bert_input_ids, bert_input_masks
+
+def create_request_data():
+    text = "This is a sample sentence to test the BERT model."
+    bert_input_ids, bert_input_masks = run_preprocessing(text)
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'distilbert_sst2'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['bert_input_ids'].CopyFrom(make_tensor_proto(bert_input_ids, shape=[1,128]))
+    data.inputs['bert_input_masks'].CopyFrom(make_tensor_proto(bert_input_masks, shape=[1,128]))
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/distilbert_sst2.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/distilbert_sst2.py
@@ -5,6 +5,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 from keras.preprocessing.text import Tokenizer
 from keras.utils import pad_sequences
+from google.protobuf.json_format import MessageToJson
 
 def run_preprocessing(text):
     tokenizer = Tokenizer()
@@ -23,4 +24,5 @@ def create_request_data():
     data.model_spec.signature_name = 'serving_default'
     data.inputs['bert_input_ids'].CopyFrom(make_tensor_proto(bert_input_ids, shape=[1,128]))
     data.inputs['bert_input_masks'].CopyFrom(make_tensor_proto(bert_input_masks, shape=[1,128]))
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/preprocess/inception_v3.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/inception_v3.py
@@ -5,6 +5,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 import numpy as np
 from PIL import Image
+from google.protobuf.json_format import MessageToJson
 
 def get_file_path(filename):
     return os.path.join(os.path.dirname(__file__), filename)
@@ -25,4 +26,5 @@ def create_request_data():
     data.model_spec.name = 'inception_v3'
     data.model_spec.signature_name = 'serving_default'
     data.inputs['input_3'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/preprocess/inception_v3.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/inception_v3.py
@@ -1,0 +1,28 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+import numpy as np
+from PIL import Image
+
+def get_file_path(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+# 이미지 로드 및 전처리 (for inception)
+def run_preprocessing(image_file_path):
+    img = Image.open(get_file_path(image_file_path))
+    img = img.resize((299, 299))
+    img_array = np.array(img)
+    img_array = (img_array - np.mean(img_array)) / np.std(img_array) 
+    img_array = img_array.astype(np.float32)
+    img_array = np.expand_dims(img_array, axis=0)
+    return img_array
+
+def create_request_data():
+    image_file_path = "../../../../dataset/imagenet/imagenet_1000_raw/n01843383_1.JPEG"
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'inception_v3'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['input_3'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v1.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v1.py
@@ -1,0 +1,27 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+import numpy as np
+from PIL import Image
+
+def get_file_path(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+# 이미지 로드 및 전처리 (for mobilenet)
+def run_preprocessing(image_file_path):
+    img = Image.open(get_file_path(image_file_path))
+    img = img.resize((224, 224))
+    img_array = np.array(img)
+    img_array = img_array.astype('float32') / 255.0
+    img_array = np.expand_dims(img_array, axis=0)
+    return img_array
+
+def create_request_data():
+    image_file_path = "../../../../dataset/imagenet/imagenet_1000_raw/n01843383_1.JPEG"
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'mobilenet_v1'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['input_1'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v1.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v1.py
@@ -5,6 +5,8 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 import numpy as np
 from PIL import Image
+from google.protobuf.json_format import MessageToJson
+
 
 def get_file_path(filename):
     return os.path.join(os.path.dirname(__file__), filename)
@@ -24,4 +26,5 @@ def create_request_data():
     data.model_spec.name = 'mobilenet_v1'
     data.model_spec.signature_name = 'serving_default'
     data.inputs['input_1'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v2.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v2.py
@@ -1,0 +1,28 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+import numpy as np
+from PIL import Image
+import json
+
+def get_file_path(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+# 이미지 로드 및 전처리 (for mobilenet)
+def run_preprocessing(image_file_path):
+    img = Image.open(get_file_path(image_file_path))
+    img = img.resize((224, 224))
+    img_array = np.array(img)
+    img_array = img_array.astype('float32') / 255.0
+    img_array = np.expand_dims(img_array, axis=0)
+    return img_array
+
+def create_request_data(bucket_name=""):
+    image_file_path = "../../../../dataset/imagenet/imagenet_1000_raw/n01843383_1.JPEG"
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'mobilenet_v2'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['input_2'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v2.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/mobilenet_v2.py
@@ -5,7 +5,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 import numpy as np
 from PIL import Image
-import json
+from google.protobuf.json_format import MessageToJson
 
 def get_file_path(filename):
     return os.path.join(os.path.dirname(__file__), filename)
@@ -25,4 +25,5 @@ def create_request_data(bucket_name=""):
     data.model_spec.name = 'mobilenet_v2'
     data.model_spec.signature_name = 'serving_default'
     data.inputs['input_2'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/preprocess/yolo_v5.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/yolo_v5.py
@@ -1,0 +1,28 @@
+#image 전처리 library
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from tensorflow_serving.apis import predict_pb2
+from tensorflow import make_tensor_proto
+import numpy as np
+import cv2
+
+def get_file_path(filename):
+    return os.path.join(os.path.dirname(__file__), filename)
+
+# 이미지 로드 및 전처리 (for yolo)
+def run_preprocessing(image_file_path):
+    img = cv2.imread(get_file_path(image_file_path))
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    img = cv2.resize(img, (640, 640))
+    img = img.astype('float32') / 255.0
+    img = np.expand_dims(img, axis=0)
+    return img
+
+def create_request_data():
+    image_file_path = "../../../../dataset/coco_2017/coco/images/val2017/000000000139.jpg"
+    data = predict_pb2.PredictRequest()
+    data.model_spec.name = 'yolo_v5'
+    data.model_spec.signature_name = 'serving_default'
+    data.inputs['x'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
+   
+    return data

--- a/bench/bench_in_faas/gcp_run/preprocess/yolo_v5.py
+++ b/bench/bench_in_faas/gcp_run/preprocess/yolo_v5.py
@@ -5,6 +5,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow import make_tensor_proto
 import numpy as np
 import cv2
+from google.protobuf.json_format import MessageToJson
 
 def get_file_path(filename):
     return os.path.join(os.path.dirname(__file__), filename)
@@ -24,5 +25,5 @@ def create_request_data():
     data.model_spec.name = 'yolo_v5'
     data.model_spec.signature_name = 'serving_default'
     data.inputs['x'].CopyFrom(make_tensor_proto(run_preprocessing(image_file_path)))
-   
-    return data
+    json_data = MessageToJson(data)
+    return json_data

--- a/bench/bench_in_faas/gcp_run/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/run_bench.py
@@ -33,7 +33,7 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_ad
             "request_data": request_data,
             "log_group_name": log_group_name,
             "log_stream_name": log_stream_name,
-            "server_address":  f"https://{model_name.replace('_','-')}.{gcp_run_default_address}/",
+            "server_address":  f"{model_name.replace('_','-')}-{gcp_run_default_address}",
             "use_https": use_https
          }
       })

--- a/bench/bench_in_faas/gcp_run/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/run_bench.py
@@ -1,0 +1,52 @@
+import json
+import time
+import concurrent.futures
+import variables
+import requests
+import boto3
+import importlib
+
+logs_client = boto3.client('logs')
+faas_bench = ""
+
+def create_log_stream(log_group_name, log_stream_name):
+    logs_client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
+
+def request_predict(server_address, data):
+    headers = {"content-type": "application/json"}
+    url = f"https://{server_address}/"
+    response = requests.post(url, data=data, headers=headers)
+    result = response.text
+    return result
+
+def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_address, use_https, log_group_name):
+  for i, model_name in enumerate(model_names):
+    global faas_bench
+    faas_bench = importlib.import_module(f"preprocess.{model_name}")
+    request_data = faas_bench.create_request_data()
+    for k, num_task in enumerate(num_tasks):
+      current_timestamp = time.strftime("%Y-%m-%d-%H_%M_%S", time.localtime())
+      log_stream_name = f"{current_timestamp}-{model_name}-{num_task}tasks"
+      data = json.dumps({
+         "inputs": {
+            "model_name": model_name,
+            "request_data": request_data,
+            "log_group_name": log_group_name,
+            "log_stream_name": log_stream_name,
+            "server_address":  f"https://{model_name.replace('_','-')}.{gcp_run_default_address}/",
+            "use_https": use_https
+         }
+      })
+      create_log_stream(log_group_name, log_stream_name)
+      with concurrent.futures.ThreadPoolExecutor(max_workers=num_task) as executor:
+        futures = [executor.submit(lambda: request_predict(gcp_function_address, data)) for _ in range(num_task)]
+      for future in concurrent.futures.as_completed(futures):
+        result = future.result()
+      time.sleep(5)
+
+start_bench(variables.model_names,
+            variables.num_tasks,
+            variables.gcp_function_address,
+            variables.gcp_run_default_address,
+            variables.use_https,
+            variables.log_group_name)

--- a/bench/bench_in_faas/gcp_run/variables.py.sample
+++ b/bench/bench_in_faas/gcp_run/variables.py.sample
@@ -1,7 +1,7 @@
 # GCP Run 추론 요청 서버의 주소, 모델 이름 설정
 # 추론 시, https://<region name>-<project name>.cloudfunctions.net/<function name>과 같은 형식으로 진행된다.
 gcp_function_address = ''
-# gcp_run bench default address
+# gcp_run bench default address ex) xxxxxxxxxx.du.a.run.app
 gcp_run_default_address = ''
 # grpc https options
 use_https = "1"

--- a/bench/bench_in_faas/gcp_run/variables.py.sample
+++ b/bench/bench_in_faas/gcp_run/variables.py.sample
@@ -1,4 +1,5 @@
 # GCP Run 추론 요청 서버의 주소, 모델 이름 설정
+# ex) <region name>-<project name>.cloudfunctions.net/<function name>
 # 추론 시, https://<region name>-<project name>.cloudfunctions.net/<function name>과 같은 형식으로 진행된다.
 gcp_function_address = ''
 # gcp_run bench default address ex) xxxxxxxxxx.du.a.run.app

--- a/bench/bench_in_faas/gcp_run/variables.py.sample
+++ b/bench/bench_in_faas/gcp_run/variables.py.sample
@@ -1,0 +1,13 @@
+# GCP Run 추론 요청 서버의 주소, 모델 이름 설정
+# 추론 시, https://<region name>-<project name>.cloudfunctions.net/<function name>과 같은 형식으로 진행된다.
+gcp_function_address = ''
+# gcp_run bench default address
+gcp_run_default_address = ''
+# grpc https options
+use_https = "1"
+# 추론을 테스트할 모델 이름들
+model_names = ["mobilenet_v1","mobilenet_v2","inception_v3","yolo_v5","bert_imdb"]
+# 테스트 추론 횟수들 지정 (병렬로 한번에 처리됩니다.)
+num_tasks = [1,10,30]
+# CloudWatch Logs Log Group Name
+log_group_name = ''

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/models/mobilenet_v1
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt
+!/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/app.py

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./models/mobilenet_v1 /app/mobilenet_v1
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8500
+
+CMD ["python", "main.py"]
+

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
@@ -1,0 +1,38 @@
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from concurrent import futures
+import grpc
+import numpy as np
+from tensorflow import make_ndarray
+from tensorflow import make_tensor_proto
+from tensorflow.keras.models import load_model
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import time
+
+class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
+    def __init__(self):
+        self.model = load_model('./mobilenet_v1')
+
+    def Predict(self, request, context):
+        start_time = time.time()
+        model_input = make_ndarray(request.inputs["input_1"])
+        model_output = self.model.predict([model_input])
+        response = predict_pb2.PredictResponse()
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        end_time = time.time()
+        inference_time = end_time - start_time
+        inference_time_numpy = np.array(inference_time)
+        response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        return response
+
+def serve():
+    print("Starting grpc server...")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
+    server.add_insecure_port('[::]:8500')
+    server.start()
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    serve()

--- a/build_assets/gcp_run_python_dockerfiles/requirements.txt
+++ b/build_assets/gcp_run_python_dockerfiles/requirements.txt
@@ -1,0 +1,4 @@
+tensorflow-cpu==2.11.1
+tensorflow-serving-api==2.11.1
+protobuf==3.19.6
+grpcio==1.54.2

--- a/build_gcp_run_python_docker_image.sh.sample
+++ b/build_gcp_run_python_docker_image.sh.sample
@@ -5,11 +5,11 @@ model_names=( "mobilenet_v1" "mobilenet_v2" "inception_v3" "yolo_v5" "bert_imdb"
 
 for model_name in "${model_names[@]}"
 do
-  sudo DOCKER_BUILDKIT=1 docker build -t $DOCKER_REGISTRY/gcp-run-$model_name-$API:latest -f ./build_assets/gcp_run_python_dockerfiles/$model_name/Dockerfile . --build-arg DOCKERIGNORE_FILE=./build_assets/gcp_run_python_dockerfiles/$model_name/.dockerignore
+  sudo DOCKER_BUILDKIT=1 docker build -t $DOCKER_REGISTRY/gcp-run-$model_name-grpc:latest -f ./build_assets/gcp_run_python_dockerfiles/$model_name/Dockerfile . --build-arg DOCKERIGNORE_FILE=./build_assets/gcp_run_python_dockerfiles/$model_name/.dockerignore
   sudo docker builder prune -f
 done
 
 for model_name in "${model_names[@]}"
 do
-  sudo docker push $DOCKER_REGISTRY/gcp-run-$model_name-$API:latest
+  sudo docker push $DOCKER_REGISTRY/gcp-run-$model_name-grpc:latest
 done

--- a/build_gcp_run_python_docker_image.sh.sample
+++ b/build_gcp_run_python_docker_image.sh.sample
@@ -1,0 +1,15 @@
+#!/bin/bash
+#you need to login Artifact Registry (docker login)
+DOCKER_REGISTRY=""
+model_names=( "mobilenet_v1" "mobilenet_v2" "inception_v3" "yolo_v5" "bert_imdb" )
+
+for model_name in "${model_names[@]}"
+do
+  sudo DOCKER_BUILDKIT=1 docker build -t $DOCKER_REGISTRY/gcp-run-$model_name-$API:latest -f ./build_assets/gcp_run_python_dockerfiles/$model_name/Dockerfile . --build-arg DOCKERIGNORE_FILE=./build_assets/gcp_run_python_dockerfiles/$model_name/.dockerignore
+  sudo docker builder prune -f
+done
+
+for model_name in "${model_names[@]}"
+do
+  sudo docker push $DOCKER_REGISTRY/gcp-run-$model_name-$API:latest
+done


### PR DESCRIPTION
AWS Lambda의 경우와 유사하게 GCP Functions를 이용하여 분산하여 요청을 보내는 것 작업 완료했습니다.
- GCP Function (bench 요청을 보내는 function) IaC
- GCP VM 에서 GCP Function에 동시에 요청을 보내는 코드
- grpc protobuf request를 생성하는 preprocessing 코드

### GCP Function 분산 요청 후 Instance Count
<img width="423" alt="image" src="https://github.com/ddps-lab/serverless-container-performance-comparison/assets/49053299/686e741c-5267-482d-8228-5f82ca5caf29">

### GCP Function을 통한 분산 요청으로 GCP Run Container Instance가 여러개 켜지는 모습
<img width="427" alt="image" src="https://github.com/ddps-lab/serverless-container-performance-comparison/assets/49053299/e5b66c81-1d81-4f57-8c88-e7e63b0b38b0">

### GCP Run으로 추론 한 결과 Network Latency 예시
<img width="1078" alt="image" src="https://github.com/ddps-lab/serverless-container-performance-comparison/assets/49053299/ed1730c5-6f5d-4f61-ac52-e1c17d8cb2ea">
대략 평균 0.1초로 상당히 기존 REST에 비해 빠른것을 확인할 수 있습니다. (내부 print를 통해 정상적으로 tensor값이 출력되는 것도 확인하였습니다.)

### Todo:
- Network Latency의 경우 손쉽게 측정가능하지만 Inference Time은 어떻게 측정할 것인가?
- prometheus를 활용하는 방법이 생각되었으나, tfserving에서 prometheus에 metric을 제공하기 위해선 REST API Port도 열어야 함. 그러나 현재 tfserving은 grpc port(Cloud Run은 하나의 포트만 가능)만 열 수 있기 때문에 고민이 되는 요소임.
