### PR TITLE
Python 기반 gRPC predict server code & IaC 완료

### DIFF
--- a/bench/bench_in_faas/gcp_run/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/build_assets/main.py
@@ -28,7 +28,7 @@ def predict(stub, data):
     request_time = time.time()
     response = stub.Predict(data, timeout=100.0)
     response_time = time.time()
-    inference_time = response.outputs['elapsed_time'].double_val[0]
+    inference_time = response.outputs['inference_time'].double_val[0]
     network_latency_time = response_time - request_time
     return response, inference_time, network_latency_time
 

--- a/build_assets/gcp_run_python_dockerfiles/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/.dockerignore
@@ -1,0 +1,3 @@
+*
+!/build_assets/gcp_run_python_dockerfiles/Dockerfile
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt

--- a/build_assets/gcp_run_python_dockerfiles/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+RUN pip install --no-cache-dir -r requirements.txt

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/.dockerignore
@@ -1,4 +1,3 @@
 *
 !/models/bert_imdb
-!/build_assets/gcp_run_python_dockerfiles/requirements.txt
 !/build_assets/gcp_run_python_dockerfiles/bert_imdb/app.py

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/models/bert_imdb
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt
+!/build_assets/gcp_run_python_dockerfiles/bert_imdb/app.py

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./models/bert_imdb /app/bert_imdb
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8500
+
+CMD ["python", "main.py"]
+

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.10.11
+FROM gcp_run_python_docker_base
 
 WORKDIR /app
 
 COPY ./models/bert_imdb /app/bert_imdb
 
-COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
-
 COPY ./build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8500
 

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
@@ -1,0 +1,40 @@
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from concurrent import futures
+import grpc
+import numpy as np
+from tensorflow import make_ndarray
+from tensorflow import make_tensor_proto
+from tensorflow.keras.models import load_model
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import time
+
+class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
+    def __init__(self):
+        self.model = load_model('./bert_imdb')
+
+    def Predict(self, request, context):
+        start_time = time.time()
+        input_ids = make_ndarray(request.inputs["input_ids"])
+        input_masks = make_ndarray(request.inputs["input_ids"])
+        segment_ids = make_ndarray(request.inputs["segment_ids"])
+        model_output = self.model.predict([input_masks, input_ids, segment_ids])
+        response = predict_pb2.PredictResponse()
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        end_time = time.time()
+        inference_time = end_time - start_time
+        inference_time_numpy = np.array(inference_time)
+        response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        return response
+
+def serve():
+    print("Starting grpc server...")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
+    server.add_insecure_port('[::]:8500')
+    server.start()
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    serve()

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
@@ -31,8 +31,8 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 def serve():
     print("Starting grpc server...")
     server_options = [
-        ('grpc.max_send_message_length', 50*50*1024),
-        ('grpc.max_receive_message_length', 50*50*1024)
+        ('grpc.max_send_message_length', 50*1024*1024),
+        ('grpc.max_receive_message_length', 50*1024*1024)
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/main.py
@@ -30,7 +30,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 
 def serve():
     print("Starting grpc server...")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    server_options = [
+        ('grpc.max_send_message_length', 50*50*1024),
+        ('grpc.max_receive_message_length', 50*50*1024)
+    ]
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
     server.add_insecure_port('[::]:8500')
     server.start()

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/models/inception_v3
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt
+!/build_assets/gcp_run_python_dockerfiles/inception_v3/app.py

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/.dockerignore
@@ -1,4 +1,3 @@
 *
 !/models/inception_v3
-!/build_assets/gcp_run_python_dockerfiles/requirements.txt
 !/build_assets/gcp_run_python_dockerfiles/inception_v3/app.py

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.10.11
+FROM gcp_run_python_docker_base
 
 WORKDIR /app
 
 COPY ./models/inception_v3 /app/inception_v3
 
-COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
-
 COPY ./build_assets/gcp_run_python_dockerfiles/inception_v3/main.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8500
 

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./models/inception_v3 /app/inception_v3
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/inception_v3/main.py /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8500
+
+CMD ["python", "main.py"]
+

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
@@ -29,8 +29,8 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 def serve():
     print("Starting grpc server...")
     server_options = [
-        ('grpc.max_send_message_length', 50*50*1024),
-        ('grpc.max_receive_message_length', 50*50*1024)
+        ('grpc.max_send_message_length', 50*1024*1024),
+        ('grpc.max_receive_message_length', 50*1024*1024)
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
@@ -28,7 +28,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 
 def serve():
     print("Starting grpc server...")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    server_options = [
+        ('grpc.max_send_message_length', 50*50*1024),
+        ('grpc.max_receive_message_length', 50*50*1024)
+    ]
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
     server.add_insecure_port('[::]:8500')
     server.start()

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/main.py
@@ -1,0 +1,38 @@
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from concurrent import futures
+import grpc
+import numpy as np
+from tensorflow import make_ndarray
+from tensorflow import make_tensor_proto
+from tensorflow.keras.models import load_model
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import time
+
+class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
+    def __init__(self):
+        self.model = load_model('./inception_v3')
+
+    def Predict(self, request, context):
+        start_time = time.time()
+        model_input = make_ndarray(request.inputs["input_3"])
+        model_output = self.model.predict([model_input])
+        response = predict_pb2.PredictResponse()
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        end_time = time.time()
+        inference_time = end_time - start_time
+        inference_time_numpy = np.array(inference_time)
+        response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        return response
+
+def serve():
+    print("Starting grpc server...")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
+    server.add_insecure_port('[::]:8500')
+    server.start()
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    serve()

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/.dockerignore
@@ -1,4 +1,3 @@
 *
 !/models/mobilenet_v1
-!/build_assets/gcp_run_python_dockerfiles/requirements.txt
 !/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/app.py

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.10.11
+FROM gcp_run_python_docker_base
 
 WORKDIR /app
 
 COPY ./models/mobilenet_v1 /app/mobilenet_v1
 
-COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
-
 COPY ./build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8500
 

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
@@ -29,8 +29,8 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 def serve():
     print("Starting grpc server...")
     server_options = [
-        ('grpc.max_send_message_length', 50*50*1024),
-        ('grpc.max_receive_message_length', 50*50*1024)
+        ('grpc.max_send_message_length', 50*1024*1024),
+        ('grpc.max_receive_message_length', 50*1024*1024)
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/main.py
@@ -28,7 +28,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 
 def serve():
     print("Starting grpc server...")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    server_options = [
+        ('grpc.max_send_message_length', 50*50*1024),
+        ('grpc.max_receive_message_length', 50*50*1024)
+    ]
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
     server.add_insecure_port('[::]:8500')
     server.start()

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/models/mobilenet_v2
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt
+!/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/app.py

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/.dockerignore
@@ -1,4 +1,3 @@
 *
 !/models/mobilenet_v2
-!/build_assets/gcp_run_python_dockerfiles/requirements.txt
 !/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/app.py

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.10.11
+FROM gcp_run_python_docker_base
 
 WORKDIR /app
 
 COPY ./models/mobilenet_v2 /app/mobilenet_v2
 
-COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
-
 COPY ./build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8500
 

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./models/mobilenet_v2 /app/mobilenet_v2
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8500
+
+CMD ["python", "main.py"]
+

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
@@ -1,0 +1,38 @@
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from concurrent import futures
+import grpc
+import numpy as np
+from tensorflow import make_ndarray
+from tensorflow import make_tensor_proto
+from tensorflow.keras.models import load_model
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import time
+
+class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
+    def __init__(self):
+        self.model = load_model('./mobilenet_v2')
+
+    def Predict(self, request, context):
+        start_time = time.time()
+        model_input = make_ndarray(request.inputs["input_2"])
+        model_output = self.model.predict([model_input])
+        response = predict_pb2.PredictResponse()
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        end_time = time.time()
+        inference_time = end_time - start_time
+        inference_time_numpy = np.array(inference_time)
+        response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        return response
+
+def serve():
+    print("Starting grpc server...")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
+    server.add_insecure_port('[::]:8500')
+    server.start()
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    serve()

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
@@ -29,8 +29,8 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 def serve():
     print("Starting grpc server...")
     server_options = [
-        ('grpc.max_send_message_length', 50*50*1024),
-        ('grpc.max_receive_message_length', 50*50*1024)
+        ('grpc.max_send_message_length', 50*1024*1024),
+        ('grpc.max_receive_message_length', 50*1024*1024)
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/main.py
@@ -28,7 +28,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 
 def serve():
     print("Starting grpc server...")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    server_options = [
+        ('grpc.max_send_message_length', 50*50*1024),
+        ('grpc.max_receive_message_length', 50*50*1024)
+    ]
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
     server.add_insecure_port('[::]:8500')
     server.start()

--- a/build_assets/gcp_run_python_dockerfiles/requirements.txt
+++ b/build_assets/gcp_run_python_dockerfiles/requirements.txt
@@ -1,4 +1,4 @@
-tensorflow-cpu==2.11.1
+tensorflow==2.11.1
 tensorflow-serving-api==2.11.1
 protobuf==3.19.6
 grpcio==1.54.2

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/.dockerignore
@@ -1,4 +1,3 @@
 *
 !/models/yolo_v5
-!/build_assets/gcp_run_python_dockerfiles/requirements.txt
 !/build_assets/gcp_run_python_dockerfiles/yolo_v5/app.py

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/.dockerignore
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/.dockerignore
@@ -1,0 +1,4 @@
+*
+!/models/yolo_v5
+!/build_assets/gcp_run_python_dockerfiles/requirements.txt
+!/build_assets/gcp_run_python_dockerfiles/yolo_v5/app.py

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.10.11
+
+WORKDIR /app
+
+COPY ./models/yolo_v5 /app/yolo_v5
+
+COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
+
+COPY ./build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8500
+
+CMD ["python", "main.py"]
+

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/Dockerfile
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/Dockerfile
@@ -1,14 +1,10 @@
-FROM python:3.10.11
+FROM gcp_run_python_docker_base
 
 WORKDIR /app
 
 COPY ./models/yolo_v5 /app/yolo_v5
 
-COPY ./build_assets/gcp_run_python_dockerfiles/requirements.txt /app
-
 COPY ./build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py /app
-
-RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8500
 

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
@@ -5,6 +5,7 @@ import grpc
 import numpy as np
 from tensorflow import make_ndarray
 from tensorflow import make_tensor_proto
+from tensorflow import convert_to_tensor
 from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
@@ -17,9 +18,10 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
     def Predict(self, request, context):
         start_time = time.time()
         model_input = make_ndarray(request.inputs["x"])
-        model_output = self.model([model_input])
+        model_output = self.model(model_input)
         response = predict_pb2.PredictResponse()
-        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        model_output_tensor = convert_to_tensor(model_output)
+        response.outputs["output"].CopyFrom(model_output_tensor)
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
@@ -29,8 +29,8 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 def serve():
     print("Starting grpc server...")
     server_options = [
-        ('grpc.max_send_message_length', 50*50*1024),
-        ('grpc.max_receive_message_length', 50*50*1024)
+        ('grpc.max_send_message_length', 50*1024*1024),
+        ('grpc.max_receive_message_length', 50*1024*1024)
     ]
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
@@ -28,7 +28,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
 
 def serve():
     print("Starting grpc server...")
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    server_options = [
+        ('grpc.max_send_message_length', 50*50*1024),
+        ('grpc.max_receive_message_length', 50*50*1024)
+    ]
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000), options=server_options)
     prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
     server.add_insecure_port('[::]:8500')
     server.start()

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
@@ -21,7 +21,7 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         model_output = self.model(model_input)
         response = predict_pb2.PredictResponse()
         model_output_tensor = convert_to_tensor(model_output)
-        response.outputs["output"].CopyFrom(model_output_tensor)
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output_tensor))
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/main.py
@@ -1,0 +1,38 @@
+import os
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+from concurrent import futures
+import grpc
+import numpy as np
+from tensorflow import make_ndarray
+from tensorflow import make_tensor_proto
+from tensorflow.keras.models import load_model
+from tensorflow_serving.apis import predict_pb2
+from tensorflow_serving.apis import prediction_service_pb2_grpc
+import time
+
+class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
+    def __init__(self):
+        self.model = load_model('./yolo_v5')
+
+    def Predict(self, request, context):
+        start_time = time.time()
+        model_input = make_ndarray(request.inputs["x"])
+        model_output = self.model([model_input])
+        response = predict_pb2.PredictResponse()
+        response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
+        end_time = time.time()
+        inference_time = end_time - start_time
+        inference_time_numpy = np.array(inference_time)
+        response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        return response
+
+def serve():
+    print("Starting grpc server...")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1000))
+    prediction_service_pb2_grpc.add_PredictionServiceServicer_to_server(PredictionServiceServicer(), server)
+    server.add_insecure_port('[::]:8500')
+    server.start()
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    serve()

--- a/build_gcp_run_python_docker_image.sh.sample
+++ b/build_gcp_run_python_docker_image.sh.sample
@@ -2,7 +2,7 @@
 #you need to login Artifact Registry (docker login)
 DOCKER_REGISTRY=""
 model_names=( "mobilenet_v1" "mobilenet_v2" "inception_v3" "yolo_v5" "bert_imdb" )
-
+sudo DOCKER_BUILDKIT=1 docker build -t gcp_run_python_docker_base -f ./build_assets/gcp_run_python_dockerfiles/Dockerfile . --build-arg DOCKERIGNORE_FILE=./build_assets/gcp_run_python_dockerfiles/.dockerignore
 for model_name in "${model_names[@]}"
 do
   sudo DOCKER_BUILDKIT=1 docker build -t $DOCKER_REGISTRY/gcp-run-$model_name-grpc:latest -f ./build_assets/gcp_run_python_dockerfiles/$model_name/Dockerfile . --build-arg DOCKERIGNORE_FILE=./build_assets/gcp_run_python_dockerfiles/$model_name/.dockerignore


### PR DESCRIPTION
C++ based tfserving과 Lambda의 python 기반 tensorflow predict가 fair하지 않은 문제를
동일 버전 Python/tensorflow을 사용하고 gRPC로 Docker Container Image를 Cloud Run에 배포하였습니다.

mobilenet_v1 100개 요청 해본 결과 : (inference_time은 tfserving과 큰 차이가 없음을 확인했으며, network_latency는 소폭 증가한 것을 확인했으나 REST보다는 여전히 빠른 수치입니다.)
<img width="1010" alt="image" src="https://github.com/ddps-lab/serverless-container-performance-comparison/assets/49053299/59ac3bee-f7f7-4300-a3e1-cbc3ca0cdc38">

### 해결된 issue
- Python 기반으로 만들어졌기 떄문에 clear하게 inference_time과 network_latency_time을 확인할 수 있습니다. (기존과 동일하게 cloudwatch logs로 빠르게 확인가능)
- tfserving을 사용하지 않고 동일한 python version, tensorflow version을 사용하고 API Endpoint 만 customizing 한 것이기 떄문에 일관성 입증 가능

### 현재 issue
- Cloud Function을 통해 분산 요청을 보낼때, 100개를 넘기면 요청이 정상적으로 되지 않는 문제가 있습니다.
- 그래도 왜 gRPC를 통한 요청이 네트워크 지연시간 뿐만 아니라 추론시간도 빠른가?
  - 제가 추측하기로는, 보내 줄때부터 tensorflow가 바로 사용할 수 있는 data 형식 (tensorflow에 최적화된 protobuf 및 tensor_proto)를 사용하기 때문에 추가적인 변환과정이 불필요하여 속도가 빠른 것 같습니다.
  - 또는, CloudRun에 사용되는 CPU가 애초에 성능이 좋은 것도 배제할 순 없을 것 같습니다. (이는 cloudrun에 lambda와 동일한 코드를 올려서 테스트해봐야할 것 같습니다. 근데 그러면 flask나 fastapi를 사용해야 해서 상대적인 성능 열화가 있을 것으로도 예상됩니다.)

내일 바로 CloudRun의 모든 spec 경우의 수에 대한 figure를 제작해보도록 하겠습니다.