### PR TITLE
Cold Start 측정 관련 코드 추가 및 하드웨어 정보 확인 코드 추가

### DIFF
--- a/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
+++ b/IaC/GCP-Run-IaC/cloudrun/cloudrun.tf
@@ -1,6 +1,6 @@
 resource "google_cloud_run_service" "cloudrun_service" {
   count    = length(var.APIS)
-  name     = "${replace(var.model_name, "_", "-")}-${var.APIS[count.index]}"
+  name     = "${var.prefix}-${replace(var.model_name, "_", "-")}-${var.APIS[count.index]}"
   location = var.region
   template {
     spec {

--- a/bench/bench_in_faas/aws_lambda/build_assets/app.py
+++ b/bench/bench_in_faas/aws_lambda/build_assets/app.py
@@ -48,7 +48,7 @@ def lambda_handler(event,context):
         download_start_time = time.time()
         s3_resource.Bucket(bucket_name).download_file("predict_data.npy", "/tmp/tmp_file")
         download_time = time.time() - download_start_time
-    create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result, upload_time+network_latency_time+download_time)
+    create_log_event(log_group_name, log_stream_name, request_time - result['start_time'], result, upload_time+network_latency_time+download_time)
     response = {
         'statusCode': 200,
         'body': "Success"

--- a/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
+++ b/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
@@ -52,7 +52,7 @@ def lambda_handler(event,context):
         download_start_time = time.time()
         s3_resource.Bucket(bucket_name).download_file("predict_data.npy", "/tmp/tmp_file")
         download_time = time.time() - download_start_time
-    create_log_event(log_group_name, log_stream_name, float(result['start_time']) - request_time, result, upload_time+network_latency_time+download_time)
+    create_log_event(log_group_name, log_stream_name, request_time - float(result['start_time']), result, upload_time+network_latency_time+download_time)
     response = {
         'statusCode': 200,
         'body': "Success"

--- a/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
+++ b/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
@@ -14,10 +14,11 @@ def predict(sagemaker_endpoint, data, bucket_name):
     network_latency_time = response_time - request_time
     return response, network_latency_time
 
-def create_log_event(log_group_name, log_stream_name, result, network_latency_time):
+def create_log_event(log_group_name, log_stream_name, start_latency_time, result, network_latency_time):
     result_json = json.loads(result)
     logs_client = boto3.client('logs')
     log_data = {
+        'start_latency_time': start_latency_time,
         'inference_time': result_json['inference_time'],
         'network_latency_time': network_latency_time,
         'cpu_info': result_json['cpu_info'],
@@ -43,6 +44,7 @@ def lambda_handler(event,context):
     upload_time = json_body['inputs']['upload_time']
     bucket_name = json_body['inputs']['bucket_name']
     sagemaker_endpoint = f"{aws_sagemaker_endpoint_prefix}-{model_name.replace('_','-')}-endpoint"
+    request_time = time.time()
     result, network_latency_time = predict(sagemaker_endpoint, request_data, bucket_name)
     download_time = 0
     if (model_name == "yolo_v5" or model_name == "inception_v3"):
@@ -50,7 +52,7 @@ def lambda_handler(event,context):
         download_start_time = time.time()
         s3_resource.Bucket(bucket_name).download_file("predict_data.npy", "/tmp/tmp_file")
         download_time = time.time() - download_start_time
-    create_log_event(log_group_name, log_stream_name, result, upload_time+network_latency_time+download_time)
+    create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result, upload_time+network_latency_time+download_time)
     response = {
         'statusCode': 200,
         'body': "Success"

--- a/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
+++ b/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
@@ -14,11 +14,11 @@ def predict(sagemaker_endpoint, data, bucket_name):
     network_latency_time = response_time - request_time
     return response, network_latency_time
 
-def create_log_event(log_group_name, log_stream_name, start_latency_time, result, network_latency_time):
+def create_log_event(log_group_name, log_stream_name, request_time, result, network_latency_time):
     result_json = json.loads(result)
     logs_client = boto3.client('logs')
     log_data = {
-        'start_latency_time': start_latency_time,
+        'start_latency_time': result_json['start_time'] - request_time,
         'inference_time': result_json['inference_time'],
         'network_latency_time': network_latency_time,
         'cpu_info': result_json['cpu_info'],
@@ -52,7 +52,7 @@ def lambda_handler(event,context):
         download_start_time = time.time()
         s3_resource.Bucket(bucket_name).download_file("predict_data.npy", "/tmp/tmp_file")
         download_time = time.time() - download_start_time
-    create_log_event(log_group_name, log_stream_name, request_time - float(result['start_time']), result, upload_time+network_latency_time+download_time)
+    create_log_event(log_group_name, log_stream_name, request_time, result, upload_time+network_latency_time+download_time)
     response = {
         'statusCode': 200,
         'body': "Success"

--- a/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
+++ b/bench/bench_in_faas/aws_sagemaker/build_assets/app.py
@@ -52,7 +52,7 @@ def lambda_handler(event,context):
         download_start_time = time.time()
         s3_resource.Bucket(bucket_name).download_file("predict_data.npy", "/tmp/tmp_file")
         download_time = time.time() - download_start_time
-    create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result, upload_time+network_latency_time+download_time)
+    create_log_event(log_group_name, log_stream_name, float(result['start_time']) - request_time, result, upload_time+network_latency_time+download_time)
     response = {
         'statusCode': 200,
         'body': "Success"

--- a/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
@@ -38,10 +38,10 @@ def create_log_event(log_group_name, log_stream_name, start_latency_time, respon
         'start_latency_time': start_latency_time,
         'inference_time': response.outputs['inference_time'].double_val[0],
         'network_latency_time': network_latency_time,
-        'cpu_info': json.loads(response.outputs['cpu_info'].double_val[0]),
-        'mem_info': json.loads(response.outputs['mem_info'].double_val[0]),
-        'num_cores': response.outputs['num_cores'].double_val[0],
-        'mem_bytes': response.outputs['mem_bytes'].double_val[0],
+        'cpu_info': json.loads(response.outputs['cpu_info'].string_val[0]),
+        'mem_info': json.loads(response.outputs['mem_info'].string_val[0]),
+        'num_cores': response.outputs['num_cores'].int64_val[0],
+        'mem_bytes': response.outputs['mem_bytes'].int64_val[0],
         'mem_gib': response.outputs['mem_gib'].double_val[0]
     }
     log_event = {

--- a/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
@@ -64,7 +64,7 @@ def function_handler(request):
         request_time = time.time()
         stub = create_grpc_stub(server_address, use_https)
         response, start_time, network_latency_time = predict(stub, protobuf_message)
-        create_log_event(log_group_name, log_stream_name, start_time - request_time, response, network_latency_time)
+        create_log_event(log_group_name, log_stream_name, request_time - start_time, response, network_latency_time)
         return json.dumps({'body': "Success"}), 200, {'Content-Type': 'application/json'}
     else:
         return json.dumps({

--- a/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/grpc/build_assets/main.py
@@ -32,9 +32,12 @@ def predict(stub, data):
     network_latency_time = response_time - request_time
     return response, start_time, network_latency_time
 
-def create_log_event(log_group_name, log_stream_name, start_latency_time, response, network_latency_time):
+def create_log_event(log_group_name, log_stream_name, start_latency_time, response, network_latency_time, bench_execute_latency_time):
     logs_client = boto3.client('logs', aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, region_name=aws_region)
+    container_instance_id = (response.outputs['container_instance_id'].string_val[0]).decode('utf-8')
     log_data = {
+        'container_instance_id': container_instance_id[-20:],
+        'bench_execute_latency_time': bench_execute_latency_time,
         'start_latency_time': start_latency_time,
         'inference_time': response.outputs['inference_time'].double_val[0],
         'network_latency_time': network_latency_time,
@@ -42,7 +45,7 @@ def create_log_event(log_group_name, log_stream_name, start_latency_time, respon
         'mem_info': json.loads(response.outputs['mem_info'].string_val[0]),
         'num_cores': response.outputs['num_cores'].int64_val[0],
         'mem_bytes': response.outputs['mem_bytes'].int64_val[0],
-        'mem_gib': response.outputs['mem_gib'].double_val[0]
+        'mem_gib': response.outputs['mem_gib'].double_val[0],
     }
     log_event = {
         'timestamp':int (time.time() * 1000),
@@ -53,18 +56,20 @@ def create_log_event(log_group_name, log_stream_name, start_latency_time, respon
 @functions_framework.http
 def function_handler(request):
     if request.method == 'POST':
+        bench_execute_time = time.time()
         json_body = request.get_json(silent=True)
         log_group_name = json_body['inputs']['log_group_name']
         log_stream_name = json_body['inputs']['log_stream_name']
         server_address = json_body['inputs']['server_address']
         use_https = json_body['inputs']['use_https']
         request_data = json_body['inputs']['request_data']
+        bench_execute_request_time = json_body['inputs']['bench_execute_request_time']
         protobuf_message = predict_pb2.PredictRequest()
         ParseDict(json.loads(request_data), protobuf_message)
         request_time = time.time()
         stub = create_grpc_stub(server_address, use_https)
         response, start_time, network_latency_time = predict(stub, protobuf_message)
-        create_log_event(log_group_name, log_stream_name, start_time - request_time, response, network_latency_time)
+        create_log_event(log_group_name, log_stream_name, start_time - request_time, response, network_latency_time, bench_execute_time - bench_execute_request_time)
         return json.dumps({'body': "Success"}), 200, {'Content-Type': 'application/json'}
     else:
         return json.dumps({

--- a/bench/bench_in_faas/gcp_run/grpc/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/grpc/run_bench.py
@@ -27,8 +27,10 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_prefix, gc
     for k, num_task in enumerate(num_tasks):
       current_timestamp = time.strftime("%Y-%m-%d-%H_%M_%S", time.localtime())
       log_stream_name = f"{current_timestamp}-{model_name}-{num_task}tasks"
+      bench_execute_request_time = time.time()
       data = json.dumps({
          "inputs": {
+            "bench_execute_request_time": bench_execute_request_time,
             "model_name": model_name,
             "request_data": request_data,
             "log_group_name": log_group_name,

--- a/bench/bench_in_faas/gcp_run/grpc/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/grpc/run_bench.py
@@ -19,7 +19,7 @@ def request_predict(server_address, data):
     result = response.text
     return result
 
-def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_address, use_https, log_group_name):
+def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_prefix, gcp_run_default_address, use_https, log_group_name):
   for i, model_name in enumerate(model_names):
     global faas_bench
     faas_bench = importlib.import_module(f"preprocess.{model_name}")
@@ -33,7 +33,7 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_ad
             "request_data": request_data,
             "log_group_name": log_group_name,
             "log_stream_name": log_stream_name,
-            "server_address":  f"{model_name.replace('_','-')}-grpc-{gcp_run_default_address}",
+            "server_address":  f"{gcp_run_prefix}-{model_name.replace('_','-')}-grpc-{gcp_run_default_address}",
             "use_https": use_https
          }
       })
@@ -47,6 +47,7 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_ad
 start_bench(variables.model_names,
             variables.num_tasks,
             variables.gcp_function_address,
+            variables.gcp_run_prefix,
             variables.gcp_run_default_address,
             variables.use_https,
             variables.log_group_name)

--- a/bench/bench_in_faas/gcp_run/grpc/variables.py.sample
+++ b/bench/bench_in_faas/gcp_run/grpc/variables.py.sample
@@ -2,7 +2,9 @@
 # ex) <region name>-<project name>.cloudfunctions.net/<function name>
 # 추론 시, https://<region name>-<project name>.cloudfunctions.net/<function name>과 같은 형식으로 진행된다.
 gcp_function_address = ''
-# gcp_run bench default address ex) xxxxxxxxxx.du.a.run.app
+# gcp_run prefix
+gcp_run_prefix = ''
+# gcp_run bench default address ex) $prefix-xxxxxxxxxx.du.a.run.app
 gcp_run_default_address = ''
 # grpc https options
 use_https = "1"

--- a/bench/bench_in_faas/gcp_run/rest/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/rest/build_assets/main.py
@@ -47,7 +47,7 @@ def function_handler(request):
         request_data = json_body['inputs']['request_data']
         request_time = time.time()
         result, network_latency_time = predict(server_address, request_data)
-        create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result, network_latency_time)
+        create_log_event(log_group_name, log_stream_name, request_time - result['start_time'], result, network_latency_time)
         return json.dumps({'body': "Success"}), 200, {'Content-Type': 'application/json'}
     else:
         return json.dumps({

--- a/bench/bench_in_faas/gcp_run/rest/build_assets/main.py
+++ b/bench/bench_in_faas/gcp_run/rest/build_assets/main.py
@@ -19,12 +19,17 @@ def predict(server_address, data):
     result = response.json()
     return result, network_latency_time
 
-def create_log_event(log_group_name, log_stream_name, start_latency_time, inference_time, network_latency_time):
+def create_log_event(log_group_name, log_stream_name, start_latency_time, result, network_latency_time):
     logs_client = boto3.client('logs', aws_access_key_id=aws_access_key, aws_secret_access_key=aws_secret_key, region_name=aws_region)
     log_data = {
         'start_latency_time': start_latency_time,
-        'inference_time': inference_time,
-        'network_latency_time': network_latency_time
+        'inference_time': result['inference_time'],
+        'network_latency_time': network_latency_time,
+        'cpu_info': result['cpu_info'],
+        'mem_info': result['mem_info'],
+        'num_cores': result['num_cores'],
+        'mem_bytes': result['mem_bytes'],
+        'mem_gib': result['mem_gib']
     }
     log_event = {
         'timestamp':int (time.time() * 1000),
@@ -42,7 +47,7 @@ def function_handler(request):
         request_data = json_body['inputs']['request_data']
         request_time = time.time()
         result, network_latency_time = predict(server_address, request_data)
-        create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result['inference_time'], network_latency_time)
+        create_log_event(log_group_name, log_stream_name, result['start_time'] - request_time, result, network_latency_time)
         return json.dumps({'body': "Success"}), 200, {'Content-Type': 'application/json'}
     else:
         return json.dumps({

--- a/bench/bench_in_faas/gcp_run/rest/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/rest/run_bench.py
@@ -27,8 +27,10 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_prefix, gc
     for k, num_task in enumerate(num_tasks):
       current_timestamp = time.strftime("%Y-%m-%d-%H_%M_%S", time.localtime())
       log_stream_name = f"{current_timestamp}-{model_name}-{num_task}tasks"
+      bench_execute_request_time = time.time()
       data = json.dumps({
          "inputs": {
+            "bench_execute_request_time": bench_execute_request_time,
             "request_data": request_data,
             "log_group_name": log_group_name,
             "log_stream_name": log_stream_name,

--- a/bench/bench_in_faas/gcp_run/rest/run_bench.py
+++ b/bench/bench_in_faas/gcp_run/rest/run_bench.py
@@ -19,7 +19,7 @@ def request_predict(server_address, data):
     result = response.text
     return result
 
-def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_address, log_group_name):
+def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_prefix, gcp_run_default_address, log_group_name):
   for i, model_name in enumerate(model_names):
     global faas_bench
     faas_bench = importlib.import_module(f"preprocess.{model_name}")
@@ -32,7 +32,7 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_ad
             "request_data": request_data,
             "log_group_name": log_group_name,
             "log_stream_name": log_stream_name,
-            "server_address":  f"https://{model_name.replace('_','-')}-rest-{gcp_run_default_address}/",
+            "server_address":  f"https://{gcp_run_prefix}-{model_name.replace('_','-')}-rest-{gcp_run_default_address}/",
          }
       })
       create_log_stream(log_group_name, log_stream_name)
@@ -45,5 +45,6 @@ def start_bench(model_names, num_tasks, gcp_function_address, gcp_run_default_ad
 start_bench(variables.model_names,
             variables.num_tasks,
             variables.gcp_function_address,
+            variables.gcp_run_prefix,
             variables.gcp_run_default_address,
             variables.log_group_name)

--- a/bench/bench_in_faas/gcp_run/rest/variables.py.sample
+++ b/bench/bench_in_faas/gcp_run/rest/variables.py.sample
@@ -2,7 +2,9 @@
 # ex) <region name>-<project name>.cloudfunctions.net/<function name>
 # 추론 시, https://<region name>-<project name>.cloudfunctions.net/<function name>과 같은 형식으로 진행된다.
 gcp_function_address = ''
-# gcp_run bench default address ex) xxxxxxxxxx.du.a.run.app
+# gcp_run prefix
+gcp_run_prefix = ''
+# gcp_run bench default address ex) $prefix-xxxxxxxxxx.du.a.run.app
 gcp_run_default_address = ''
 # 추론을 테스트할 모델 이름들
 model_names = ["mobilenet_v1","mobilenet_v2","inception_v3","yolo_v5","bert_imdb"]

--- a/build_assets/aws_lambda_dockerfiles/bert_imdb/app.py
+++ b/build_assets/aws_lambda_dockerfiles/bert_imdb/app.py
@@ -19,6 +19,7 @@ def lambda_handler(event, context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': result.tolist()

--- a/build_assets/aws_lambda_dockerfiles/bert_imdb/app.py
+++ b/build_assets/aws_lambda_dockerfiles/bert_imdb/app.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -16,13 +18,45 @@ def lambda_handler(event, context):
     segment_ids = np.array(json_body['inputs']['segment_ids'])
     result = model.predict([input_masks, input_ids, segment_ids])
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
-            'body': result.tolist()
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
+            'body': result.tolist(),
         })
     }
     return response

--- a/build_assets/aws_lambda_dockerfiles/distilbert_sst2/app.py
+++ b/build_assets/aws_lambda_dockerfiles/distilbert_sst2/app.py
@@ -18,6 +18,7 @@ def lambda_handler(event, context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': result.tolist()

--- a/build_assets/aws_lambda_dockerfiles/distilbert_sst2/app.py
+++ b/build_assets/aws_lambda_dockerfiles/distilbert_sst2/app.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -15,12 +17,44 @@ def lambda_handler(event, context):
     bert_input_masks = np.array(json_body['inputs']['bert_input_masks'])
     result = model([bert_input_masks, bert_input_ids])
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
             'body': result.tolist()
         })
     }

--- a/build_assets/aws_lambda_dockerfiles/inception_v3/app.py
+++ b/build_assets/aws_lambda_dockerfiles/inception_v3/app.py
@@ -17,6 +17,7 @@ def lambda_handler(event,context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': result.tolist()

--- a/build_assets/aws_lambda_dockerfiles/inception_v3/app.py
+++ b/build_assets/aws_lambda_dockerfiles/inception_v3/app.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -14,12 +16,44 @@ def lambda_handler(event,context):
     input_3 = json_body['inputs']['input_3']
     result = model.predict(np.array(input_3))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
             'body': result.tolist()
         })
     }

--- a/build_assets/aws_lambda_dockerfiles/mobilenet_v1/app.py
+++ b/build_assets/aws_lambda_dockerfiles/mobilenet_v1/app.py
@@ -17,6 +17,7 @@ def lambda_handler(event,context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': result.tolist()

--- a/build_assets/aws_lambda_dockerfiles/mobilenet_v1/app.py
+++ b/build_assets/aws_lambda_dockerfiles/mobilenet_v1/app.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -14,12 +16,44 @@ def lambda_handler(event,context):
     input_1 = json_body['inputs']['input_1']
     result = model.predict(np.array(input_1))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
             'body': result.tolist()
         })
     }

--- a/build_assets/aws_lambda_dockerfiles/mobilenet_v2/app.py
+++ b/build_assets/aws_lambda_dockerfiles/mobilenet_v2/app.py
@@ -17,6 +17,7 @@ def lambda_handler(event,context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': result.tolist()

--- a/build_assets/aws_lambda_dockerfiles/mobilenet_v2/app.py
+++ b/build_assets/aws_lambda_dockerfiles/mobilenet_v2/app.py
@@ -2,6 +2,8 @@ import json
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -14,12 +16,44 @@ def lambda_handler(event,context):
     input_2 = json_body['inputs']['input_2']
     result = model.predict(np.array(input_2))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
             'body': result.tolist()
         })
     }

--- a/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
+++ b/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
@@ -23,6 +23,7 @@ def lambda_handler(event,context):
     response = {
         'statusCode': 200,
         'body': json.dumps({
+            'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
             'body': "S3 Uploaded"

--- a/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
+++ b/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
@@ -3,6 +3,8 @@ import boto3
 import numpy as np
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import time
 model_load_start_time = time.time()
 from tensorflow.keras.models import load_model
@@ -20,12 +22,44 @@ def lambda_handler(event,context):
     np.save('/tmp/predict_data', result)
     s3.Bucket(s3_bucket_name).upload_file("/tmp/predict_data.npy", "predict_data.npy")
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'statusCode': 200,
         'body': json.dumps({
             'start_time': start_time,
             'loading_time': model_load_end_time - model_load_start_time,
             'inference_time': end_time - start_time,
+            'mem_bytes': mem_bytes,
+            'mem_gib': mem_gib,
+            'num_cores': num_cores,
+            'cpu_info': cpu_info,
+            'mem_info': mem_info,
             'body': "S3 Uploaded"
         })
     }

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 from concurrent import futures
 import grpc
 import numpy as np
@@ -9,6 +11,7 @@ from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
+import json
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -24,10 +27,47 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
         end_time = time.time()
         inference_time = end_time - start_time
+        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+        mem_gib = mem_bytes/(1024.**3)
+        num_cores = multiprocessing.cpu_count()
+        cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+        cpu_info_output = cpu_info_cat.stdout
+        cpu_info = []
+        current_cpu = {}
+        for line in cpu_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_cpu[key.strip()] = value.strip()
+            else:
+                cpu_info.append(current_cpu)
+                current_cpu = {}
+        cpu_info.append(current_cpu)
+        mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+        mem_info_output = mem_info_cat.stdout
+        mem_info = []
+        current_mem = {}
+        for line in mem_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_mem[key.strip()] = value.strip()
+            else:
+                mem_info.append(current_mem)
+                current_mem = {}
+        mem_info.append(current_mem)
         inference_time_numpy = np.array(inference_time)
         start_time_numpy = np.array(start_time)
+        mem_bytes_numpy = np.array(mem_bytes)
+        mem_gib_numpy = np.array(mem_gib)
+        num_cores_numpy = np.array(num_cores)
+        cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
+        mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
+        response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
+        response.outputs["mem_gib"].CopyFrom(make_tensor_proto(mem_gib_numpy, shape=list(mem_gib_numpy.shape)))
+        response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
+        response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
+        response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
@@ -12,6 +12,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
 import json
+import requests
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -61,6 +62,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         num_cores_numpy = np.array(num_cores)
         cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
         mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
+        metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+        metadata_headers = {'Metadata-Flavor': 'Google'}
+        container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+        string_container_instance_id = container_instance_id.text
+        container_instance_id_numpy = np.array(string_container_instance_id)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
@@ -68,6 +74,7 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
         response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
         response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
+        response.outputs["container_instance_id"].CopyFrom(make_tensor_proto(container_instance_id_numpy, shape=list(container_instance_id_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/grpc_main.py
@@ -25,7 +25,9 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)
+        start_time_numpy = np.array(start_time)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
@@ -18,6 +18,7 @@ async def predict(json_body: dict):
     result = model.predict([input_masks, input_ids, segment_ids])
     end_time = time.time()
     response = {
+        'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
         'body': result.tolist(),

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import numpy as np
 import time
 from fastapi import FastAPI
@@ -17,10 +19,42 @@ async def predict(json_body: dict):
     segment_ids = np.array(json_body['inputs']['segment_ids'])
     result = model.predict([input_masks, input_ids, segment_ids])
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
+        'mem_bytes': mem_bytes,
+        'mem_gib': mem_gib,
+        'num_cores': num_cores,
+        'cpu_info': cpu_info,
+        'mem_info': mem_info,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/bert_imdb/rest_main.py
@@ -4,6 +4,7 @@ import subprocess
 import multiprocessing
 import numpy as np
 import time
+import requests
 from fastapi import FastAPI
 app = FastAPI()
 model_load_start_time = time.time()
@@ -46,6 +47,10 @@ async def predict(json_body: dict):
             mem_info.append(current_mem)
             current_mem = {}
     mem_info.append(current_mem)
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    metadata_headers = {'Metadata-Flavor': 'Google'}
+    container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+    string_container_instance_id = container_instance_id.text
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
@@ -55,6 +60,7 @@ async def predict(json_body: dict):
         'num_cores': num_cores,
         'cpu_info': cpu_info,
         'mem_info': mem_info,
+        'container_instance_id': string_container_instance_id,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/grpc_main.py
@@ -23,7 +23,9 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)
+        start_time_numpy = np.array(start_time)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/grpc_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 from concurrent import futures
 import grpc
 import numpy as np
@@ -9,6 +11,8 @@ from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
+import json
+
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -22,10 +26,47 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
         end_time = time.time()
         inference_time = end_time - start_time
+        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+        mem_gib = mem_bytes/(1024.**3)
+        num_cores = multiprocessing.cpu_count()
+        cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+        cpu_info_output = cpu_info_cat.stdout
+        cpu_info = []
+        current_cpu = {}
+        for line in cpu_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_cpu[key.strip()] = value.strip()
+            else:
+                cpu_info.append(current_cpu)
+                current_cpu = {}
+        cpu_info.append(current_cpu)
+        mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+        mem_info_output = mem_info_cat.stdout
+        mem_info = []
+        current_mem = {}
+        for line in mem_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_mem[key.strip()] = value.strip()
+            else:
+                mem_info.append(current_mem)
+                current_mem = {}
+        mem_info.append(current_mem)
         inference_time_numpy = np.array(inference_time)
         start_time_numpy = np.array(start_time)
+        mem_bytes_numpy = np.array(mem_bytes)
+        mem_gib_numpy = np.array(mem_gib)
+        num_cores_numpy = np.array(num_cores)
+        cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
+        mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
+        response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
+        response.outputs["mem_gib"].CopyFrom(make_tensor_proto(mem_gib_numpy, shape=list(mem_gib_numpy.shape)))
+        response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
+        response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
+        response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
@@ -16,6 +16,7 @@ async def predict(json_body: dict):
     result = model.predict(np.array(input_3))
     end_time = time.time()
     response = {
+        'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
         'body': result.tolist(),

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import numpy as np
 import time
 from fastapi import FastAPI
@@ -15,10 +17,42 @@ async def predict(json_body: dict):
     input_3 = json_body['inputs']['input_3']
     result = model.predict(np.array(input_3))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
+        'mem_bytes': mem_bytes,
+        'mem_gib': mem_gib,
+        'num_cores': num_cores,
+        'cpu_info': cpu_info,
+        'mem_info': mem_info,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
@@ -4,6 +4,7 @@ import subprocess
 import multiprocessing
 import numpy as np
 import time
+import requests
 from fastapi import FastAPI
 app = FastAPI()
 model_load_start_time = time.time()
@@ -32,6 +33,10 @@ async def predict(json_body: dict):
             cpu_info.append(current_cpu)
             current_cpu = {}
     cpu_info.append(current_cpu)
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    metadata_headers = {'Metadata-Flavor': 'Google'}
+    container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+    string_container_instance_id = container_instance_id.text
     mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
     mem_info_output = mem_info_cat.stdout
     mem_info = []
@@ -53,6 +58,7 @@ async def predict(json_body: dict):
         'num_cores': num_cores,
         'cpu_info': cpu_info,
         'mem_info': mem_info,
+        'container_instance_id': string_container_instance_id,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
@@ -23,7 +23,9 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)
+        start_time_numpy = np.array(start_time)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
@@ -12,6 +12,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
 import json
+import requests
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -59,6 +60,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         num_cores_numpy = np.array(num_cores)
         cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
         mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
+        metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+        metadata_headers = {'Metadata-Flavor': 'Google'}
+        container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+        string_container_instance_id = container_instance_id.text
+        container_instance_id_numpy = np.array(string_container_instance_id)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
@@ -66,6 +72,7 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
         response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
         response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
+        response.outputs["container_instance_id"].CopyFrom(make_tensor_proto(container_instance_id_numpy, shape=list(container_instance_id_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/grpc_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 from concurrent import futures
 import grpc
 import numpy as np
@@ -9,6 +11,7 @@ from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
+import json
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -22,10 +25,47 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
         end_time = time.time()
         inference_time = end_time - start_time
+        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+        mem_gib = mem_bytes/(1024.**3)
+        num_cores = multiprocessing.cpu_count()
+        cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+        cpu_info_output = cpu_info_cat.stdout
+        cpu_info = []
+        current_cpu = {}
+        for line in cpu_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_cpu[key.strip()] = value.strip()
+            else:
+                cpu_info.append(current_cpu)
+                current_cpu = {}
+        cpu_info.append(current_cpu)
+        mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+        mem_info_output = mem_info_cat.stdout
+        mem_info = []
+        current_mem = {}
+        for line in mem_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_mem[key.strip()] = value.strip()
+            else:
+                mem_info.append(current_mem)
+                current_mem = {}
+        mem_info.append(current_mem)
         inference_time_numpy = np.array(inference_time)
         start_time_numpy = np.array(start_time)
+        mem_bytes_numpy = np.array(mem_bytes)
+        mem_gib_numpy = np.array(mem_gib)
+        num_cores_numpy = np.array(num_cores)
+        cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
+        mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
+        response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
+        response.outputs["mem_gib"].CopyFrom(make_tensor_proto(mem_gib_numpy, shape=list(mem_gib_numpy.shape)))
+        response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
+        response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
+        response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
@@ -16,6 +16,7 @@ async def predict(json_body: dict):
     result = model.predict(np.array(input_1))
     end_time = time.time()
     response = {
+        'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
         'body': result.tolist(),

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import numpy as np
 import time
 from fastapi import FastAPI
@@ -15,10 +17,42 @@ async def predict(json_body: dict):
     input_1 = json_body['inputs']['input_1']
     result = model.predict(np.array(input_1))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
+        'mem_bytes': mem_bytes,
+        'mem_gib': mem_gib,
+        'num_cores': num_cores,
+        'cpu_info': cpu_info,
+        'mem_info': mem_info,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
@@ -4,6 +4,7 @@ import subprocess
 import multiprocessing
 import numpy as np
 import time
+import requests
 from fastapi import FastAPI
 app = FastAPI()
 model_load_start_time = time.time()
@@ -44,6 +45,10 @@ async def predict(json_body: dict):
             mem_info.append(current_mem)
             current_mem = {}
     mem_info.append(current_mem)
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    metadata_headers = {'Metadata-Flavor': 'Google'}
+    container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+    string_container_instance_id = container_instance_id.text
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
@@ -53,6 +58,7 @@ async def predict(json_body: dict):
         'num_cores': num_cores,
         'cpu_info': cpu_info,
         'mem_info': mem_info,
+        'container_instance_id': string_container_instance_id,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/grpc_main.py
@@ -23,7 +23,9 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)
+        start_time_numpy = np.array(start_time)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/grpc_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 from concurrent import futures
 import grpc
 import numpy as np
@@ -9,6 +11,8 @@ from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
+import json
+
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -22,10 +26,47 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["output"].CopyFrom(make_tensor_proto(model_output, shape=list(model_output.shape)))
         end_time = time.time()
         inference_time = end_time - start_time
+        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+        mem_gib = mem_bytes/(1024.**3)
+        num_cores = multiprocessing.cpu_count()
+        cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+        cpu_info_output = cpu_info_cat.stdout
+        cpu_info = []
+        current_cpu = {}
+        for line in cpu_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_cpu[key.strip()] = value.strip()
+            else:
+                cpu_info.append(current_cpu)
+                current_cpu = {}
+        cpu_info.append(current_cpu)
+        mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+        mem_info_output = mem_info_cat.stdout
+        mem_info = []
+        current_mem = {}
+        for line in mem_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_mem[key.strip()] = value.strip()
+            else:
+                mem_info.append(current_mem)
+                current_mem = {}
+        mem_info.append(current_mem)
         inference_time_numpy = np.array(inference_time)
         start_time_numpy = np.array(start_time)
+        mem_bytes_numpy = np.array(mem_bytes)
+        mem_gib_numpy = np.array(mem_gib)
+        num_cores_numpy = np.array(num_cores)
+        cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
+        mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
+        response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
+        response.outputs["mem_gib"].CopyFrom(make_tensor_proto(mem_gib_numpy, shape=list(mem_gib_numpy.shape)))
+        response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
+        response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
+        response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
@@ -16,6 +16,7 @@ async def predict(json_body: dict):
     result = model.predict(np.array(input_2))
     end_time = time.time()
     response = {
+        'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
         'body': result.tolist(),

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import numpy as np
 import time
 from fastapi import FastAPI
@@ -15,10 +17,42 @@ async def predict(json_body: dict):
     input_2 = json_body['inputs']['input_2']
     result = model.predict(np.array(input_2))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
+        'mem_bytes': mem_bytes,
+        'mem_gib': mem_gib,
+        'num_cores': num_cores,
+        'cpu_info': cpu_info,
+        'mem_info': mem_info,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
@@ -4,6 +4,7 @@ import subprocess
 import multiprocessing
 import numpy as np
 import time
+import requests
 from fastapi import FastAPI
 app = FastAPI()
 model_load_start_time = time.time()
@@ -44,6 +45,10 @@ async def predict(json_body: dict):
             mem_info.append(current_mem)
             current_mem = {}
     mem_info.append(current_mem)
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    metadata_headers = {'Metadata-Flavor': 'Google'}
+    container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+    string_container_instance_id = container_instance_id.text
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
@@ -53,6 +58,7 @@ async def predict(json_body: dict):
         'num_cores': num_cores,
         'cpu_info': cpu_info,
         'mem_info': mem_info,
+        'container_instance_id': string_container_instance_id,
         'body': result.tolist(),
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/requirements.grpc.txt
+++ b/build_assets/gcp_run_python_dockerfiles/requirements.grpc.txt
@@ -2,3 +2,4 @@ tensorflow==2.11.1
 tensorflow-serving-api==2.11.1
 protobuf==3.19.6
 grpcio==1.54.2
+requests

--- a/build_assets/gcp_run_python_dockerfiles/requirements.rest.txt
+++ b/build_assets/gcp_run_python_dockerfiles/requirements.rest.txt
@@ -1,3 +1,4 @@
 tensorflow-cpu==2.11.1
 fastapi==0.95.2
 uvicorn[standard]==0.22.0
+requests

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 from concurrent import futures
 import grpc
 import numpy as np
@@ -10,6 +12,7 @@ from tensorflow.keras.models import load_model
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
+import json
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -24,10 +27,47 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["output"].CopyFrom(make_tensor_proto(model_output_tensor))
         end_time = time.time()
         inference_time = end_time - start_time
+        mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+        mem_gib = mem_bytes/(1024.**3)
+        num_cores = multiprocessing.cpu_count()
+        cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+        cpu_info_output = cpu_info_cat.stdout
+        cpu_info = []
+        current_cpu = {}
+        for line in cpu_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_cpu[key.strip()] = value.strip()
+            else:
+                cpu_info.append(current_cpu)
+                current_cpu = {}
+        cpu_info.append(current_cpu)
+        mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+        mem_info_output = mem_info_cat.stdout
+        mem_info = []
+        current_mem = {}
+        for line in mem_info_output.splitlines():
+            if line.strip():
+                key, value = line.split(':',1)
+                current_mem[key.strip()] = value.strip()
+            else:
+                mem_info.append(current_mem)
+                current_mem = {}
+        mem_info.append(current_mem)
         inference_time_numpy = np.array(inference_time)
         start_time_numpy = np.array(start_time)
+        mem_bytes_numpy = np.array(mem_bytes)
+        mem_gib_numpy = np.array(mem_gib)
+        num_cores_numpy = np.array(num_cores)
+        cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
+        mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
+        response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
+        response.outputs["mem_gib"].CopyFrom(make_tensor_proto(mem_gib_numpy, shape=list(mem_gib_numpy.shape)))
+        response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
+        response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
+        response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
@@ -25,7 +25,9 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         end_time = time.time()
         inference_time = end_time - start_time
         inference_time_numpy = np.array(inference_time)
+        start_time_numpy = np.array(start_time)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
+        response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/grpc_main.py
@@ -13,6 +13,7 @@ from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2_grpc
 import time
 import json
+import requests
 
 class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceServicer):
     def __init__(self):
@@ -61,6 +62,11 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         num_cores_numpy = np.array(num_cores)
         cpu_info_numpy = np.array(json.dumps(cpu_info).encode('utf-8'))
         mem_info_numpy = np.array(json.dumps(mem_info).encode('utf-8'))
+        metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+        metadata_headers = {'Metadata-Flavor': 'Google'}
+        container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+        string_container_instance_id = container_instance_id.text
+        container_instance_id_numpy = np.array(string_container_instance_id)
         response.outputs["inference_time"].CopyFrom(make_tensor_proto(inference_time_numpy, shape=list(inference_time_numpy.shape)))
         response.outputs["start_time"].CopyFrom(make_tensor_proto(start_time_numpy, shape=list(start_time_numpy.shape)))
         response.outputs["mem_bytes"].CopyFrom(make_tensor_proto(mem_bytes_numpy, shape=list(mem_bytes_numpy.shape)))
@@ -68,6 +74,7 @@ class PredictionServiceServicer(prediction_service_pb2_grpc.PredictionServiceSer
         response.outputs["num_cores"].CopyFrom(make_tensor_proto(num_cores_numpy, shape=list(num_cores_numpy.shape)))
         response.outputs["cpu_info"].CopyFrom(make_tensor_proto(cpu_info_numpy, shape=list(cpu_info_numpy.shape)))
         response.outputs["mem_info"].CopyFrom(make_tensor_proto(mem_info_numpy, shape=list(mem_info_numpy.shape)))
+        response.outputs["container_instance_id"].CopyFrom(make_tensor_proto(container_instance_id_numpy, shape=list(container_instance_id_numpy.shape)))
         return response
 
 def serve():

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
@@ -4,6 +4,7 @@ import subprocess
 import multiprocessing
 import numpy as np
 import time
+import requests
 from fastapi import FastAPI
 app = FastAPI()
 model_load_start_time = time.time()
@@ -44,6 +45,10 @@ async def predict(json_body: dict):
             mem_info.append(current_mem)
             current_mem = {}
     mem_info.append(current_mem)
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/id"
+    metadata_headers = {'Metadata-Flavor': 'Google'}
+    container_instance_id = requests.get(metadata_url, headers=metadata_headers)
+    string_container_instance_id = container_instance_id.text
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
@@ -53,6 +58,7 @@ async def predict(json_body: dict):
         'num_cores': num_cores,
         'cpu_info': cpu_info,
         'mem_info': mem_info,
+        'container_instance_id': string_container_instance_id,
         'body': result,
     }
     return response

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
@@ -16,6 +16,7 @@ async def predict(json_body: dict):
     result = model(np.array(x))
     end_time = time.time()
     response = {
+        'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
         'body': result,

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
@@ -1,5 +1,7 @@
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
+import subprocess
+import multiprocessing
 import numpy as np
 import time
 from fastapi import FastAPI
@@ -15,10 +17,42 @@ async def predict(json_body: dict):
     x = json_body['inputs']['x']
     result = model(np.array(x))
     end_time = time.time()
+    mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
+    mem_gib = mem_bytes/(1024.**3)
+    num_cores = multiprocessing.cpu_count()
+    cpu_info_cat = subprocess.run(['cat','/proc/cpuinfo'], capture_output=True, text=True)
+    cpu_info_output = cpu_info_cat.stdout
+    cpu_info = []
+    current_cpu = {}
+    for line in cpu_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_cpu[key.strip()] = value.strip()
+        else:
+            cpu_info.append(current_cpu)
+            current_cpu = {}
+    cpu_info.append(current_cpu)
+    mem_info_cat = subprocess.run(['cat','/proc/meminfo'], capture_output=True, text=True)
+    mem_info_output = mem_info_cat.stdout
+    mem_info = []
+    current_mem = {}
+    for line in mem_info_output.splitlines():
+        if line.strip():
+            key, value = line.split(':',1)
+            current_mem[key.strip()] = value.strip()
+        else:
+            mem_info.append(current_mem)
+            current_mem = {}
+    mem_info.append(current_mem)
     response = {
         'start_time': start_time,
         'loading_time': model_load_end_time - model_load_start_time,
         'inference_time': end_time - start_time,
+        'mem_bytes': mem_bytes,
+        'mem_gib': mem_gib,
+        'num_cores': num_cores,
+        'cpu_info': cpu_info,
+        'mem_info': mem_info,
         'body': result,
     }
     return response

--- a/models/sagemaker_assets/inception_v3/inference.py
+++ b/models/sagemaker_assets/inception_v3/inference.py
@@ -58,6 +58,7 @@ def handler(data, context):
             current_mem = {}
     mem_info.append(current_mem)
     response_json = {
+        "start_time": start_time,
         "inference_time": inference_time,
         "mem_bytes": mem_bytes,
         "mem_gib": mem_gib,

--- a/models/sagemaker_assets/inference.py
+++ b/models/sagemaker_assets/inference.py
@@ -43,6 +43,7 @@ def handler(data, context):
             current_mem = {}
     mem_info.append(current_mem)
     response_json = json.loads(response.content)
+    response_json['start_time'] = start_time
     response_json['inference_time'] = inference_time
     response_json['mem_bytes'] = mem_bytes
     response_json['mem_gib'] = mem_gib

--- a/models/sagemaker_assets/yolo_v5/inference.py
+++ b/models/sagemaker_assets/yolo_v5/inference.py
@@ -58,6 +58,7 @@ def handler(data, context):
             current_mem = {}
     mem_info.append(current_mem)
     response_json = {
+        "start_time": start_time,
         "inference_time": inference_time,
         "mem_bytes": mem_bytes,
         "mem_gib": mem_gib,


### PR DESCRIPTION
1. Cold Start 측정 관련 코드를 추가했습니다.
- 요청을 보내는 시간과 handler가 실행된 시간 (요청을 받아 응답을 시작하는 순간)을 측정하고, 두 시간의 차를 start latency time으로 정의하여 cloudwatch logs에 기록하도록 코드를 추가했습니다.

2. AWS Sagemaker에만 적용되었던 하드웨어 정보 확인 코드를 모든 Lambda, Cloud Run도 기록하도록 수정하였습니다.

3. GCP Cloud Run 인프라 생성 시, prefix를 통해 서비스 생성/수정 시 완전히 별도의 이름으로 생성할 수 있도록 약간의 코드 수정을 하였습니다.