### PR TITLE
Inference Time이 높게 측정되던 문제 수정

### DIFF
--- a/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
+++ b/build_assets/aws_lambda_dockerfiles/yolo_v5/app.py
@@ -23,8 +23,9 @@ def lambda_handler(event,context):
     put_url = json_body['inputs']['put_url']
     request_data = requests.get(get_url)
     input_data = request_data.json()
+    data = np.array(input_data['inputs']['x'])
     inference_start_time = time.time()
-    result = model(input_data['inputs']['x'])
+    result = model(data)
     inference_end_time = time.time()
     requests.put(put_url, data=(np.array(result)).tobytes())
     mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')

--- a/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/inception_v3/rest_main.py
@@ -20,8 +20,9 @@ cold_start_end = time.time()
 async def predict(json_body: dict):
     execution_start_time = time.time()
     input_3 = json_body['inputs']['input_3']
+    nparray = np.array(input_3)
     inference_start_time = time.time()
-    result = model.predict(np.array(input_3))
+    result = model.predict(nparray)
     inference_end_time = time.time()
     mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     mem_gib = mem_bytes/(1024.**3)

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v1/rest_main.py
@@ -20,8 +20,9 @@ cold_start_end = time.time()
 async def predict(json_body: dict):
     execution_start_time = time.time()
     input_1 = json_body['inputs']['input_1']
+    nparray = np.array(input_1)
     inference_start_time = time.time()
-    result = model.predict(np.array(input_1))
+    result = model.predict(nparray)
     inference_end_time = time.time()
     mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     mem_gib = mem_bytes/(1024.**3)

--- a/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/mobilenet_v2/rest_main.py
@@ -20,8 +20,9 @@ cold_start_end = time.time()
 async def predict(json_body: dict):
     execution_start_time = time.time()
     input_2 = json_body['inputs']['input_2']
+    nparray = np.array(input_2)
     inference_start_time = time.time()
-    result = model.predict(np.array(input_2))
+    result = model.predict(nparray)
     inference_end_time = time.time()
     mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     mem_gib = mem_bytes/(1024.**3)

--- a/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
+++ b/build_assets/gcp_run_python_dockerfiles/yolo_v5/rest_main.py
@@ -20,8 +20,9 @@ cold_start_end = time.time()
 async def predict(json_body: dict):
     execution_start_time = time.time()
     x = json_body['inputs']['x']
+    nparray = np.array(x)
     inference_start_time = time.time()
-    result = model(np.array(x))
+    result = model(nparray)
     inference_end_time = time.time()
     mem_bytes = os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES')
     mem_gib = mem_bytes/(1024.**3)


### PR DESCRIPTION
AWS Lambda YoloV5 및 GCP Cloud Run (REST)에서 Inference Time이 높게 측정되던 문제를 수정하였습니다.